### PR TITLE
locale changes does not work

### DIFF
--- a/src/vue-ctk-date-time-picker/vue-ctk-date-time-picker.vue
+++ b/src/vue-ctk-date-time-picker/vue-ctk-date-time-picker.vue
@@ -199,7 +199,8 @@
       } else if (this.rangeMode) {
         this.$emit('input', this.getRangeDatesTimeFormat({}))
       }
-      moment.tz(this.timeZone).locale(this.locale)
+      moment.tz(this.timeZone)
+      moment.locale(this.locale)
     },
     methods: {
       getDateTime () {


### PR DESCRIPTION
In my case (moment 2.22.2) moment.tz(this.timeZone) somehow does not return a moment instance, so .locale(this.locale) wont work.