### PR TITLE
unSelectAllShortcuts throws an undefined error

### DIFF
--- a/src/vue-ctk-date-time-picker/_subs/CtkDateRangePicker.vue
+++ b/src/vue-ctk-date-time-picker/_subs/CtkDateRangePicker.vue
@@ -155,7 +155,9 @@
       },
       selectDate (dateTime) {
         this.$emit('change-date', dateTime)
-        this.$refs['calendar-shortcut'].unSelectAllShortcuts()
+        
+        if (this.$refs['calendar-shortcut'])
+          this.$refs['calendar-shortcut'].unSelectAllShortcuts()
       },
       selectShortcut (dateTime) {
         this.$emit('change-date', dateTime)


### PR DESCRIPTION
If the property "without-range-shortcut" is set to true, "unSelectAllShortcuts()" throws an error since the shortcut panel doesn't exist. Check that it exists before triggering the method.