### PR TITLE
Set the shortcut buttons type to 'button' to prevent form submit events

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/index.vue
@@ -10,6 +10,7 @@
       :class="{ 'is-selected': shortcut.isSelected }"
       class="shortcut-button"
       tabindex="-1"
+      type="button"
       @mouseover="shortcut.isHover = true"
       @mouseleave="shortcut.isHover = false"
       @click="select(shortcut)"


### PR DESCRIPTION
I noticed that clicking on a range shortcut button was causing my form to fire a submit event. I dug around and noticed there wasn't a `type` attribute on the shortcut buttons, so they were defaulting to `submit`.  Setting `type="button"` fixes the problem and didn't seem to introduce any regressions (in my limited testing).