### PR TITLE
Custom shortcuts on RangeDatePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Here is an example of UMD implementation: https://codepen.io/louismazel/pen/jQWN
 | dark | Boolean | no | false |
 | without-range-shortcut | Boolean | no | false |
 | shortcuts-translation (8) | Object | no | - |
-| disabled-hours (9) | Array (of String) | no | - |
+| range-shortcuts (9) | Array | no | ['this_week', 'last_7_days','last_30_days','this_month','last_month','this_year',
+'last_year']
+| disabled-hours (10) | Array (of String) | no | - |
 
 (1) hint : Is a text that replaces the label/placeholder
 
@@ -109,7 +111,19 @@ Here is an example of UMD implementation: https://codepen.io/louismazel/pen/jQWN
 }
 ```
 
-(9) disabled-hours : Must be an Array of hours in 24h format ('00' to '23') : `['00','01','02','03','04','05','06','07','19','20','21','22','23']`
+(9) range-shortcuts : Must be an Array with ShortcutTypes string:
+
+- today
+- yesterday
+- this_week
+- last_7_days
+- last_30_days
+- this_month
+- last_month
+- this_year
+- last_year
+
+(10) disabled-hours : Must be an Array of hours in 24h format ('00' to '23') : `['00','01','02','03','04','05','06','07','19','20','21','22','23']`
 
 ## Upcoming features (Todo)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,6 +80,7 @@
               v-model="rangeValues"
               :dark="darkMode"
               :shortcuts-translation="shortcutsTranslation"
+              :range-shortcuts="['last_30_days', 'last_month', 'last_year']"
               range-mode
               overlay-background
               color="purple"
@@ -95,6 +96,7 @@
               <ctk-date-time-picker
               v-model="{ start: '2018-04-05', end: '2018-04-20' }"
               range-mode
+              :range-shortcuts="['last_30_days', 'last_month', 'last_year']"
               overlay-background
               color="purple"
               format="YYYY-MM-DD"

--- a/src/VueCtkDateTimePicker/_subs/CtkDateRangePicker.vue
+++ b/src/VueCtkDateTimePicker/_subs/CtkDateRangePicker.vue
@@ -35,6 +35,7 @@
             :dark="dark"
             :date-time="dateTime"
             :shortcuts-translation="shortcutsTranslation"
+            :range-shortcuts="rangeShortcuts"
             @change-range="selectShortcut"
           />
 
@@ -97,7 +98,8 @@
       value: { type: [String, Object], default: String },
       withoutRangeShortcut: { type: Boolean, default: false },
       dark: { type: Boolean, default: Boolean },
-      shortcutsTranslation: {type: Object, default: Object}
+      shortcutsTranslation: {type: Object, default: Object},
+      rangeShortcuts: {type: Array, default: Array}
     },
     data () {
       return {

--- a/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/_subs/availableShortcutTypes.js
+++ b/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/_subs/availableShortcutTypes.js
@@ -1,0 +1,11 @@
+export default [
+  { key: 'today', value: 1, isHover: false, isSelected: true },
+  { key: 'yesterday', value: -1, isHover: false, isSelected: false },
+  { key: 'this_week', value: 'week', isHover: false, isSelected: false },
+  { key: 'last_7_days', value: 7, isHover: false, isSelected: false },
+  { key: 'last_30_days', value: 30, isHover: false, isSelected: false },
+  { key: 'this_month', value: 'month', isHover: false, isSelected: false },
+  { key: 'last_month', value: '-month', isHover: false, isSelected: false },
+  { key: 'this_year', value: 'year', isHover: false, isSelected: false },
+  { key: 'last_year', value: '-year', isHover: false, isSelected: false }
+]

--- a/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/_subs/shortcutsTranslation.json
+++ b/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/_subs/shortcutsTranslation.json
@@ -1,4 +1,6 @@
 {
+  "today": "Today",
+  "yesterday": "Yesterday",
   "this_week": "This week",
   "last_7_days": "Last 7 days",
   "last_30_days": "Last 30 days",

--- a/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/_subs/CtkCalendarShortcut/index.vue
@@ -28,6 +28,17 @@
 <script>
   import moment from 'moment'
   import shortcutsTranslation from './_subs/shortcutsTranslation'
+  import availableShortcutTypes from './_subs/availableShortcutTypes'
+
+  const defaultShortcuts = [
+    'this_week',
+    'last_7_days',
+    'last_30_days',
+    'this_month',
+    'last_month',
+    'this_year',
+    'last_year'
+  ]
 
   export default {
     name: 'CtkCalendarShortcur',
@@ -36,19 +47,17 @@
       locale: { type: String, default: String },
       dark: { type: Boolean, default: false },
       dateTime: {type: Object, default: Object},
-      shortcutsTranslation: {type: Object, default: Object}
+      shortcutsTranslation: {type: Object, default: Object},
+      rangeShortcuts: {type: Array, default: Array}
     },
     data () {
       return {
-        shortcuts: [
-          { key: 'this_week', value: 'week', isHover: false, isSelected: false },
-          { key: 'last_7_days', value: 7, isHover: false, isSelected: false },
-          { key: 'last_30_days', value: 30, isHover: false, isSelected: false },
-          { key: 'this_month', value: 'month', isHover: false, isSelected: false },
-          { key: 'last_month', value: '-month', isHover: false, isSelected: false },
-          { key: 'this_year', value: 'year', isHover: false, isSelected: false },
-          { key: 'last_year', value: '-year', isHover: false, isSelected: false }
-        ]
+        shortcuts: availableShortcutTypes.filter(sc => {
+          const selectedShortcuts = this.rangeShortcuts.length
+            ? this.rangeShortcuts
+            : defaultShortcuts
+          return selectedShortcuts.indexOf(sc.key) !== -1
+        })
       }
     },
     computed: {
@@ -87,6 +96,14 @@
         case 'week': case 'month': case 'year':
           dates.start = moment().locale(this.locale).startOf(value)
           dates.end = moment().locale(this.locale).endOf(value)
+          break
+        case -1:
+          dates.end = moment().locale(this.locale)
+          dates.start = moment().locale(this.locale).subtract(1, 'd')
+          break
+        case 1:
+          dates.end = moment().locale(this.locale).subtract(-1, 'd')
+          dates.start = moment().locale(this.locale)
           break
         case 7: case 30:
           dates.end = moment().locale(this.locale).subtract(1, 'd')

--- a/src/VueCtkDateTimePicker/index.vue
+++ b/src/VueCtkDateTimePicker/index.vue
@@ -93,6 +93,7 @@
       :without-range-shortcut="withoutRangeShortcut"
       :dark="dark"
       :shortcuts-translation="shortcutsTranslation"
+      :range-shortcuts="rangeShortcuts"
       @change-date="changeDate"
       @validate="validate"
     />
@@ -153,6 +154,7 @@
       withoutRangeShortcut: {type: Boolean, default: false},
       dark: {type: Boolean, default: false},
       shortcutsTranslation: {type: Object, default: Object},
+      rangeShortcuts: {type: Array, default: Array},
       disabledHours: {type: Array, default: Array}
     },
     data () {


### PR DESCRIPTION
1. Add custom shortcuts support
2. Add "today" and "yesterday" shortcuts

```diff
<ctk-date-time-picker
  v-model="rangeValues"
  :dark="darkMode"
  :shortcuts-translation="shortcutsTranslation"
+ :range-shortcuts="['last_30_days', 'last_month', 'last_year']"
  range-mode
  overlay-background
  color="purple"
  format="YYYY-MM-DD"
  formatted="ddd D MMM YYYY"
  label="Select range"
/>
```

![screen shot 2019-01-08 at 12 11 08 am](https://user-images.githubusercontent.com/4386549/50778913-035b5b00-12da-11e9-9897-93d52eb364fb.png)
