### PR TITLE
feature: Added enabled-dates properties

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -365,9 +365,9 @@
           {
             id: '7',
             title: 'Enabled/Disabled dates Picker',
-            description: '(disabled="false")',
+            description: '',
             editOption: false,
-            initial: 'null',
+            initial: {'disabledDates' : ["2019-02-22"], 'enabledDates' : ["2019-02-21", "2019-02-22", "2019-02-23"]},
             value: null,
             options: {
               id: 'EnabledDisabledDatesPicker',

--- a/src/App.vue
+++ b/src/App.vue
@@ -191,6 +191,7 @@
                 :disabled="demo.options.disabled"
                 :disabled-dates="demo.options.disabledDates"
                 :disabled-hours="demo.options.disabledHours"
+                :enabled-dates="demo.options.enabledDates"
                 :minute-interval="demo.options.minuteInterval"
                 :first-day-of-week="demo.options.firstDayOfWeek"
                 :min-date="demo.options.minDate"
@@ -359,6 +360,21 @@
               disabled: true,
               label: 'Is Disabled',
               id: 'DisabledPicker'
+            }
+          },
+          {
+            id: '7',
+            title: 'Enabled/Disabled dates Picker',
+            description: '(disabled="false")',
+            editOption: false,
+            initial: 'null',
+            value: null,
+            options: {
+              id: 'EnabledDisabledDatesPicker',
+              disabledDates : ['2019-02-22'],
+              enabledDates : ['2019-02-21', '2019-02-22', '2019-02-23'],
+              inline: true,
+              format: 'YYYY-MM-DD',
             }
           }
         ],

--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/DatePicker/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/DatePicker/index.vue
@@ -174,6 +174,7 @@
       noWeekendsDays: { type: Boolean, default: Boolean },
       range: { type: Boolean, default: false },
       disabledDates: { type: Array, default: Array },
+      enabledDates: { type: Array, default: Array },
       dark: { type: Boolean, default: false },
       month: { type: Object, default: Object },
       height: { type: Number, default: Number },
@@ -225,6 +226,7 @@
       isDisabled (day) {
         return (
           this.isDateDisabled(day) ||
+          !this.isDateEnabled(day) || 
           this.isBeforeMinDate(day) ||
           this.isAfterEndDate(day) ||
           (this.isWeekEndDay(day) && this.noWeekendsDays)
@@ -232,6 +234,9 @@
       },
       isDateDisabled (day) {
         return this.disabledDates.indexOf(day.format('YYYY-MM-DD')) > -1
+      },
+      isDateEnabled (day) {
+        return this.enabledDates.length == 0 || this.enabledDates.indexOf(day.format('YYYY-MM-DD')) > -1
       },
       isBeforeMinDate (day) {
         return day.isBefore(moment(this.minDate))

--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/index.vue
@@ -38,6 +38,7 @@
             :min-date="minDate"
             :max-date="maxDate"
             :disabled-dates="disabledDates"
+            :enabled-dates="enabledDates"
             :range="range"
             :no-shortcuts="noShortcuts"
             :height="height"
@@ -117,6 +118,7 @@
       noWeekendsDays: { type: Boolean, default: Boolean },
       disabledDates: { type: Array, default: Array },
       disabledHours: { type: Array, default: Array },
+      enabledDates: { type: Array, default: Array },
       range: { type: Boolean, default: Boolean },
       noShortcuts: { type: Boolean, default: Boolean },
       buttonColor: { type: String, default: String },

--- a/src/VueCtkDateTimePicker/index.vue
+++ b/src/VueCtkDateTimePicker/index.vue
@@ -50,6 +50,7 @@
       :range="range"
       :disabled-dates="disabledDates"
       :disabled-hours="disabledHours"
+      :enabled-dates="enabledDates"
       :no-shortcuts="noShortcuts"
       :button-now-translation="buttonNowTranslation"
       :no-button-now="noButtonNow"
@@ -130,6 +131,7 @@
       noButton: { type: Boolean, default: false },
       disabledDates: { type: Array, default: Array },
       disabledHours: { type: Array, default: Array },
+      enabledDates: { type: Array, default: Array },
       open: { type: Boolean, default: false },
       persistent: { type: Boolean, default: false },
       inputSize: { type: String, default: String },


### PR DESCRIPTION
Often need to limit date selection with specific dates, and it is not good to fill all possible dates in properties **disabled-dates**.
Much better to set *enabled-dates*

**Need to update documentation with:**
enabled-dates -- type:Array<String>  -- required:no -- default: - --

If enabled-dates set - only these dates will be available for select
If enabled-dates and disabled-dates set - from enabled-dates will be excluded disabled-dates