### PR TITLE
Solve the problem that the mobile end can not focus again after sliding around

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/CustomInput.vue
+++ b/src/VueCtkDateTimePicker/_subs/CustomInput.vue
@@ -92,6 +92,7 @@
     methods: {
       focusInput () {
         this.$refs.CustomInput.focus()
+        this.$emit('focus')
       }
     }
   }


### PR DESCRIPTION
The time component disappears after sliding on the mobile end. Clicking on the input box again does not appear. You need to click on the blank area before reappearing. Adding $emit to focus input solves the problem.
