### PR TITLE
removed: '!important' css flag

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/CustomInput.vue
+++ b/src/VueCtkDateTimePicker/_subs/CustomInput.vue
@@ -76,7 +76,7 @@
       borderStyle () {
         const cond = (this.isFocus && !this.errorHint)
         return cond
-          ? { border: `1px solid ${this.color} !important` }
+          ? { border: `1px solid ${this.color}` }
           : null
       },
       colorStyle () {


### PR DESCRIPTION
Never use !important when you're writing a plugin