### PR TITLE
Converted moment, moment range, and Vue to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4054,6 +4054,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.9"
       }
@@ -4663,19 +4664,21 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.47",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
-      "integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -4686,6 +4689,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -9977,12 +9981,14 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
     },
     "moment-range": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.1.tgz",
-      "integrity": "sha1-GujPIJ3e0KXOXhZgMUYmWzkGqG8=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.2.tgz",
+      "integrity": "sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==",
+      "dev": true,
       "requires": {
         "es6-symbol": "^3.1.0"
       }
@@ -10075,7 +10081,8 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -14362,9 +14369,10 @@
       }
     },
     "vue": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.9.tgz",
-      "integrity": "sha512-t1+tvH8hybPM86oNne3ZozCD02zj/VoZIiojOBPJLjwBn7hxYU5e1gBObFpq8ts1NEn1VhPf/hVXBDAJ3X5ljg=="
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
+      "dev": true
     },
     "vue-cli-plugin-webpack-bundle-analyzer": {
       "version": "1.2.0",
@@ -14490,9 +14498,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.9.tgz",
-      "integrity": "sha512-QgO0LSCdeH6zUMSgtqel+yDWsZWQPXiWBdFg9qzOhWfQL8vZ+ywinAzE04rm1XrWc+3SU0YAdWISlEgs/i8WWA==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
+      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "delete-dist-report": "rm ./dist/report.html",
     "delete:reports": "npm run delete-docs-report && npm run delete-dist-report"
   },
-  "dependencies": {
+  "peerDependencies": {
     "vue": "^2.5.22",
     "moment": "^2.24.0",
-    "moment-range": "^4.0.1",
+    "moment-range": "^4.0.1"
+  },
+  "dependencies": {
     "v-click-outside": "^2.0.2"
   },
   "devDependencies": {
@@ -39,10 +41,13 @@
     "babel-jest": "^23.6.0",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
+    "moment": "^2.24.0",
+    "moment-range": "^4.0.1",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
+    "vue": "^2.5.22",
     "vue-cli-plugin-webpack-bundle-analyzer": "^1.2.0",
-    "vue-template-compiler": "^2.6.9"
+    "vue-template-compiler": "^2.6.10"
   },
   "postcss": {
     "plugins": {

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,5 +5,12 @@ module.exports = {
     }
   },
   publicPath: './',
-  lintOnSave: undefined
+  lintOnSave: undefined,
+  configureWebpack: {
+    externals: {
+      vue: 'vue',
+      moment: 'moment',
+      'moment-range': 'moment-range'
+    }
+  }
 }


### PR DESCRIPTION
This somewhat relates to issue #116 and package size as this was discussed as a possible approach for solving that problem as well.

We we're working on our first deployment using the vue-ctk-date-time-picker, and I noticed our chunk-vendors.js compiled by Webpack was pretty big. After digging into it, I discovered that this package was importing moment, vue, and moment range as npm dependencies, which means they are included in the final dist js files. This would be ok, except our app also has moment and vue as dependencies - which means we've now included them in our final package twice by including the dist version of vue-ctk-date-picker.

This PR converts VueJS, Moment, & Moment-Range to peer dependencies which allows us to only include each of them one in our application. This would be a somewhat significant change as anyone who upgrades would need to install the 3 dependencies themselves - so I welcome feedback on the approach and how that would need to be communicated in docs.