### PR TITLE
Close datepicker when field loses focus (fix #128)

### DIFF
--- a/src/VueCtkDateTimePicker/index.vue
+++ b/src/VueCtkDateTimePicker/index.vue
@@ -21,6 +21,7 @@
       :input-size="inputSize"
       :no-clear-button="noClearButton"
       @focus="toggleDatePicker(true)"
+      @blur="toggleDatePicker(false)"
       @clear="$emit('input', null)"
     />
     <slot v-else />


### PR DESCRIPTION
This PR adds a `@blur` event listener to close the date picker when the element loses focus.

#### Context
Currently, when we focus on the datepicker, the pickers are shown. However, when we blur the field (that is, the field loses focus), the picker will remain visible.

This behaviour is not ideal, and incorrect. It makes the datepicker  unfriendly to keyboard users (among other scenarios) because you have to hit escape or manually click on something else on the page so that the pickers close.

By adding a `@blur` listener to the blur event that calls the `toggleDatePicker(false)` method, we ensure that the picker will automatically close when the field loses focus.

#### What kind of change does this PR introduce? (check at least one)

- [x]  Bugfix
- [ ]  Feature
- [ ]   Code style update
- [ ]   Refactor
- [ ]   Build-related changes
- [ ]   Other, please describe:

#### Is this PR related to a problem?
Yes, it closes https://github.com/chronotruck/vue-ctk-date-time-picker/issues/128

#### Does this PR introduce a breaking change? (check one)

 - [ ] Yes
 - [x] No


### No tests were harmed in the making of this PR.