### PR TITLE
[FIX] "Invalid date" when clicking "PM" twice

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/TimePicker.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/TimePicker.vue
@@ -391,7 +391,7 @@
           this.hour = item
         } else if (type === 'minutes') {
           this.minute = item
-        } else if (type === 'apms') {
+        } else if (type === 'apms' && this.apm !== item) {
           const newHour = item === 'pm' || item === 'PM' ? this.hour + 12 : this.hour - 12
           this.hour = newHour
           this.apm = item


### PR DESCRIPTION
Fixing the "Invalid Date" bug described here:

https://github.com/chronotruck/vue-ctk-date-time-picker/issues/196

This fix ensures that no changes are made when AM or PM is clicked more than once.