### PR TITLE
Iefixes

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/CustomButton.vue
+++ b/src/VueCtkDateTimePicker/_subs/CustomButton.vue
@@ -94,6 +94,9 @@
       transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
       transform: scale(0);
     }
+    .flex-fix {
+      display: inline-block;
+    }
     &.with-border {
       border: 1px solid #eaeaea;
     }

--- a/src/VueCtkDateTimePicker/_subs/CustomInput.vue
+++ b/src/VueCtkDateTimePicker/_subs/CustomInput.vue
@@ -155,8 +155,7 @@
       }
     }
     &-clear-button {
-      position: absolute;
-      right: 12px;
+      margin: 0 0 0 -30px;
     }
     &.has-error {
       .field-input {

--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/DatePicker/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/DatePicker/index.vue
@@ -28,16 +28,16 @@
           </button>
         </div>
         <div
-          class="datepicker-container-label flex-1 flex justify-content-center"
+          class="datepicker-container-label flex-1 justify-content-center flex"
         >
           <TransitionGroup
             :name="transitionLabelName"
-            class="h-100 flex align-center flex-1 flex justify-content-right"
+            class="h-100 flex align-center flex-1 justify-content-right"
           >
             <CustomButton
               v-for="m in [month]"
               :key="m.month"
-              class="date-buttons lm-fs-16 padding-button"
+              class="date-buttons lm-fs-16 padding-button flex-fix"
               :color="color"
               :dark="dark"
               @click="selectingYearMonth = 'month'"
@@ -47,12 +47,12 @@
           </TransitionGroup>
           <TransitionGroup
             :name="transitionLabelName"
-            class="h-100 flex align-center flex-1 flex"
+            class="h-100 flex align-center flex-1"
           >
             <CustomButton
               v-for="y in [year]"
               :key="y"
-              class="date-buttons lm-fs-16 padding-button"
+              class="date-buttons lm-fs-16 padding-button flex-fix"
               :color="color"
               :dark="dark"
               @click="selectingYearMonth = 'year'"


### PR DESCRIPTION
Issue 1: Nested Flexs with IE 11 tends to cause width issue, this was causing a problem with the Month/Year Selection Example image of just the stock repo site showing the problem in IE 11,  I added a flex-fix class and just passed it into that specific spot because just trying to avoid anything overly complex because there isn't a consistent way of fixing this issue.

![flexwithinflex](https://user-images.githubusercontent.com/124587/63805389-ef9f4c00-c8de-11e9-8f24-40d06cd4e8f8.JPG)

Issue 2:  IE 11 does not always respect heights well with certain elements, the styling change from absolute and pushing it right to relative and just pulling in the margin is a much more consistent way of getting this affect.  

![clearButton](https://user-images.githubusercontent.com/124587/63805658-88ce6280-c8df-11e9-8f31-0ed8c8ccf778.JPG)

Minor Issue: I noticed some duplicate class names in a file and fixed them, flex was used multiple times.