### PR TITLE
fix: remove disabled prop & bind rest attributes

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/CustomInput/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/CustomInput/index.vue
@@ -5,7 +5,7 @@
       'is-focused': isFocus,
       'has-value': value,
       'has-error': errorHint,
-      'is-disabled': disabled,
+      'is-disabled': isDisabled,
       'is-dark': dark,
       'no-label': noLabel
     }, inputSize]"
@@ -15,9 +15,9 @@
     <input
       :id="$attrs.id"
       ref="CustomInput"
+      v-bind="$attrs"
       :value="value"
       :placeholder="label"
-      :disabled="disabled"
       :style="[borderStyle]"
       type="text"
       class="field-input"
@@ -70,7 +70,6 @@
       hint: { type: String, default: null },
       errorHint: { type: Boolean, default: null },
       color: { type: String, default: null },
-      disabled: { type: Boolean, default: false },
       dark: { type: Boolean, default: false },
       inputSize: { type: String, default: null },
       noClearButton: { type: Boolean, default: false }
@@ -90,6 +89,14 @@
       },
       hasClearButton () {
         return !this.noClearButton && !this.disabled && this.value
+      },
+      /**
+       * Returns true if the field is disabled
+       * @function isDisabled
+       * @returns {boolean}
+       */
+      isDisabled () {
+        return typeof this.$attrs.disabled !== 'undefined' && this.$attrs.disabled !== false
       }
     },
     methods: {

--- a/src/VueCtkDateTimePicker/index.vue
+++ b/src/VueCtkDateTimePicker/index.vue
@@ -11,7 +11,7 @@
       :id="`${$attrs.id}-input`"
       ref="custom-input"
       v-model="dateFormatted"
-      :disabled="disabled"
+      v-bind="$attrs"
       :dark="dark"
       :hint="hint"
       :error-hint="error"
@@ -24,7 +24,9 @@
       @focus="toggleDatePicker(true)"
       @clear="$emit('input', null)"
     />
-    <slot v-else />
+    <slot
+      v-else
+    />
 
     <div
       v-if="hasPickerOpen && overlay"
@@ -34,7 +36,7 @@
 
     <!-- Date picker container -->
     <PickersContainer
-      v-if="!disabled"
+      v-if="!isDisabled"
       :id="`${$attrs.id}-picker-container`"
       ref="agenda"
       v-model="dateTime"
@@ -169,11 +171,19 @@
       },
       formatOutput () {
         return this.outputFormat || this.format
+      },
+      /**
+       * Returns true if the field is disabled
+       * @function isDisabled
+       * @returns {boolean}
+       */
+      isDisabled () {
+        return typeof this.$attrs.disabled !== 'undefined' && this.$attrs.disabled !== false
       }
     },
     watch: {
       open (val) {
-        if (this.disabled) return
+        if (this.isDisabled) return
         this.pickerOpen = val
       },
       locale (value) {
@@ -202,6 +212,9 @@
     },
     methods: {
       setValueToCustomElem () {
+        /**
+         * TODO: Find a way (perhaps), to bind default attrs to custom element.
+         */
         const target = this.$slots.default[0]
         if (target) {
           if (target.tag === 'input') {
@@ -264,7 +277,7 @@
         return date ? nearestMinutes(this.minuteInterval, date, this.formatOutput).format('YYYY-MM-DD HH:mm') : null
       },
       toggleDatePicker (val) {
-        if (this.disabled) return
+        if (this.isDisabled) return
         const isOpen = (val === false || val === true) ? val : !this.pickerOpen
         this.setBodyOverflow(isOpen)
         this.pickerOpen = isOpen

--- a/src/VueCtkDateTimePicker/props.js
+++ b/src/VueCtkDateTimePicker/props.js
@@ -8,7 +8,6 @@ export default {
   error: { type: Boolean, default: null },
   color: { type: String, default: 'dodgerblue' },
   buttonColor: { type: String, default: null },
-  disabled: { type: Boolean, default: false },
   dark: { type: Boolean, default: false },
   overlay: { type: Boolean, default: false },
   inline: { type: Boolean, default: false },

--- a/tests/unit/VueCtkDateTimePicker/CustomInput/index.spec.js
+++ b/tests/unit/VueCtkDateTimePicker/CustomInput/index.spec.js
@@ -40,9 +40,29 @@ describe('VueCtkDateTimePicker/CustomInput', () => {
       expect(input.attributes().id).toEqual('fieldId')
     })
 
-    /**
-     * TODO: Add tests for the disabled case
-     */
+    it('should have the disabled from the attributes', () => {
+      const wrapper = shallowMount(CustomInput, {
+        attrs: {
+          disabled: true
+        }
+      })
+
+      const input = wrapper.find('.field-input')
+      expect(input.attributes().disabled).toBeDefined()
+    })
+
+    it('should have any attribute from the attributes', () => {
+      const wrapper = shallowMount(CustomInput, {
+        attrs: {
+          name: 'hello-world',
+          rest: 'attribute'
+        }
+      })
+
+      const input = wrapper.find('.field-input')
+      expect(input.attributes().name).toEqual('hello-world')
+      expect(input.attributes().rest).toEqual('attribute')
+    })
   })
 
   /**

--- a/tests/unit/VueCtkDateTimePicker/index.spec.js
+++ b/tests/unit/VueCtkDateTimePicker/index.spec.js
@@ -40,7 +40,7 @@ describe('VueCtkDateTimePicker', () => {
     })
 
     describe('id attr', () => {
-      it('should have the id prop from the attribute', async () => {
+      it('should have the id prop from the attribute', () => {
         const wrapper = shallowMount(VueCtkDateTimePicker, {
           propsData: {
             inline: false
@@ -50,26 +50,67 @@ describe('VueCtkDateTimePicker', () => {
           }
         })
 
-        await wrapper.vm.$nextTick()
         const input = wrapper.find(CustomInput)
         expect(input.attributes().id).toEqual('myField-input')
+      })
+    })
+
+    describe('disabled attr', () => {
+      it('should have the disabled prop from the attribute', () => {
+        const wrapper = shallowMount(VueCtkDateTimePicker, {
+          propsData: {
+            inline: false
+          },
+          attrs: {
+            disabled: true
+          }
+        })
+
+        const input = wrapper.find(CustomInput)
+        expect(input.attributes().disabled).toBeDefined()
+      })
+    })
+
+    describe('name attr', () => {
+      it('should have the name attr', () => {
+        const wrapper = shallowMount(VueCtkDateTimePicker, {
+          propsData: {
+            inline: false
+          },
+          attrs: {
+            name: 'myFieldName'
+          }
+        })
+
+        const input = wrapper.find(CustomInput)
+        expect(input.attributes().name).toEqual('myFieldName')
       })
     })
   })
 
   describe('picker container', () => {
-    it('should be defined if the "disabled" prop is not defined', () => {
-      wrapper.setProps({
-        disabled: false
+    it('should be defined if the "disabled" attribute is not defined', () => {
+      const wrapper = shallowMount(VueCtkDateTimePicker, {
+        propsData: {
+          inline: false
+        },
+        attrs: {
+          disabled: false
+        }
       })
 
       const container = wrapper.find(PickersContainer)
       expect(container.exists()).toBeTruthy()
     })
 
-    it('should not be defined if the "disabled" prop is defined', () => {
-      wrapper.setProps({
-        disabled: true
+    it('should not be defined if the "disabled" attribute is defined', () => {
+      const wrapper = shallowMount(VueCtkDateTimePicker, {
+        propsData: {
+          inline: false
+        },
+        attrs: {
+          disabled: true
+        }
       })
 
       const container = wrapper.find(PickersContainer)


### PR DESCRIPTION
Instead of having a `disabled` prop, check the `disabled` attribute from the main component.
Also bind the rest attributes from the main component to the custom input.

fixes #181 
