### PR TITLE
feat: custom range shortcut value through function

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,25 @@ Here is an example of [UMD implementation](https://codepen.io/louismazel/pen/jQW
 
 Shortcut types allowed are : `['day', '-day', 'isoWeek', '-isoWeek', 'quarter', 'month', '-month', 'year', '-year', 'week', '-week']`
 For each shortcut, a `key`, `label` and `value` must be specified. The `key` is a unique key for that specific shortcut.
-If the value of shortcut is a number (Integer), this number correspond to number of day (for 5 --> Last 5 days)
 You can use this feature for translate existings shortcuts.
+If the **value of shortcut is a number** (Integer), this number correspond to number of day (for 5 --> Last 5 days).
+
+If the **value of shortcut is a function**, we'll use it to generate the `start` and `end` values. This function should return an object with the start & end values. Both values **must be a moment object**. The function is called when the user clicks on the shortcut button.
+
+```js
+[
+  {
+    key: 'customValue',
+    label: 'My custom thing',
+    value: () => {
+      return {
+        start: moment(),
+        end: moment().add(2, 'days')
+      }
+    }
+  },
+];
+```
 
 With the `shortcut` property, you can specify a shortcut that's selected by default by passing it's `key` value.
 

--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/DatePicker/_subs/RangeShortcuts.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/DatePicker/_subs/RangeShortcuts.vue
@@ -46,7 +46,8 @@
         default: () => ([]),
         validator: val => val.every(shortcut => {
           const isValueInteger = Number.isInteger(shortcut.value)
-          return shortcut.key && shortcut.label && (isValueInteger ? true : SHORTCUT_TYPES.includes(shortcut.value))
+          const isFunction = typeof shortcut.value === 'function'
+          return shortcut.key && shortcut.label && (isValueInteger || isFunction ? true : SHORTCUT_TYPES.includes(shortcut.value))
         })
       },
       height: { type: Number, required: true }
@@ -104,6 +105,22 @@
             start: moment().subtract(value, 'd'),
             end: moment(),
             value
+          }
+        }
+
+        /**
+         * Case where the value is a function that is in charge of
+         * handling the start & end values
+         */
+        if (typeof value === 'function') {
+          const { start, end } = value()
+
+          if (!start || !end) throw new Error('Missing "start" or "end" values.')
+          if (!moment.isMoment(start) || !moment.isMoment(end)) throw new Error('The "start" or "end" values are not moment objects.')
+
+          return {
+            start,
+            end
           }
         }
 


### PR DESCRIPTION
- Support a `function` as `value` for range shortcuts.

fixes #210 
