### PR TITLE
Make the label prop reactive

### DIFF
--- a/src/VueCtkDateTimePicker/index.vue
+++ b/src/VueCtkDateTimePicker/index.vue
@@ -216,6 +216,13 @@
       },
       locale (value) {
         updateMomentLocale(value, this.firstDayOfWeek)
+      },
+      label () {
+        if (this.hasCustomElem && !this.noValueToCustomElem) {
+          this.$nextTick(() => {
+            this.setValueToCustomElem()
+          })
+        }
       }
     },
     mounted () {


### PR DESCRIPTION
I ran into a problem when using the label prop dynamically and with a custom element. My particular problem was that when using Vue I18n:

```
<VueCtkDateTimePicker :label="$t('components.dateTimePicker.label')">
  <FilterButton />
</VueCtkDateTimePicker>
```

The text would just become **"COMPONENTS.DATETIMEPICKER.LABEL"** instead of changing to the corresponding translation.