### PR TITLE
Don't override font-family

### DIFF
--- a/src/VueCtkDateTimePicker/assets/main.scss
+++ b/src/VueCtkDateTimePicker/assets/main.scss
@@ -1,12 +1,4 @@
 .date-time-picker {
-  font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen,
-        Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   color: #2c3e50;
-  input, label, p, span {
-    font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen,
-        Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-  }
   @import "./../../assets/scss/helpers/index.scss";
 }


### PR DESCRIPTION
Is there any reason to hard-code the font-family in the default css? This is causing styling issues on sites not using Roboto (or any of the other fonts listed in there).

Thank you!