### PR TITLE
fix: check for the "elem" existence on scroll update

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/TimePicker.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/TimePicker.vue
@@ -370,28 +370,30 @@
           return null
         }
       },
-      initPositionView () {
+      async initPositionView () {
         this.noScrollEvent = true
         const containers = ['hours', 'minutes']
         if (this.apms) containers.push('apms')
-        setTimeout(() => {
-          containers.forEach((container) => {
-            const elem = this.$refs[container][0]
-            elem.scrollTop = 0
-            const selected = elem.querySelector(`.time-picker-column-item.active`)
-            if (selected) {
-              const boundsSelected = selected.getBoundingClientRect()
-              const boundsElem = elem.getBoundingClientRect()
-              const timePickerHeight = this.$refs['time-picker'].clientHeight
-              if (boundsSelected && boundsElem) {
-                elem.scrollTop = (28 / 2) + boundsSelected.top - boundsElem.top - timePickerHeight / 2
-              }
+
+        await this.$nextTick()
+        containers.forEach((container) => {
+          const elem = this.$refs[container][0]
+          if (!elem) return false
+
+          elem.scrollTop = 0
+          const selected = elem.querySelector(`.time-picker-column-item.active`)
+          if (selected) {
+            const boundsSelected = selected.getBoundingClientRect()
+            const boundsElem = elem.getBoundingClientRect()
+            const timePickerHeight = this.$refs['time-picker'].clientHeight
+            if (boundsSelected && boundsElem) {
+              elem.scrollTop = (28 / 2) + boundsSelected.top - boundsElem.top - timePickerHeight / 2
             }
-            setTimeout(() => {
-              this.noScrollEvent = false
-            }, 500)
-          })
-        }, 0)
+          }
+          setTimeout(() => {
+            this.noScrollEvent = false
+          }, 500)
+        })
       },
       getAvailableHour () {
         const availableHours = this.hours.find((element) => {


### PR DESCRIPTION
Remove the setTimeout usage and use $nextTick instead.

fixes #293 