### PR TITLE
Removes editorconfig rules already included in *

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,3 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.{js,jsx,ts,tsx,vue}]
-indent_style = space
-indent_size = 2
-trim_trailing_whitespace = true
-insert_final_newline = true


### PR DESCRIPTION
ef94fdc198dd6373902791bcff2baf5a3612bf7b introduced some additional rules in the .editorconfig for the `*.{js,jsx,ts,tsx,vue}` wildcard glob.

however all of these rules are already defined on the asterisk `*` wildcard. I see no reason to have these styles duplicated unless there is some kind of buggy .editorconfig implementation out there which requires both of these rules to func5tion correctly.