### PR TITLE
factor in no shortcuts for width

### DIFF
--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/index.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/index.vue
@@ -160,7 +160,9 @@
               ? this.onlyDate
                 ? '260px'
                 : '420px'
-              : '400px'
+              : this.noShortcuts
+                ? '260px'
+                : '400px'
         return {
           width: size,
           maxWidth: size,


### PR DESCRIPTION
It seems that when specifying "no shortcuts" the width of the calendar spans the whole 400px