### PR TITLE
Vue3 ref issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:unit": "vue-cli-service test:unit",
     "test:unit:watch": "vue-cli-service test:unit --watch",
     "ui": "vue ui",
+    "prepare": "npm run build",
     "delete-docs-report": "rm ./docs/report.html",
     "delete-dist-report": "rm ./dist/report.html",
     "delete:reports": "npm run delete-docs-report && npm run delete-dist-report"

--- a/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/TimePicker.vue
+++ b/src/VueCtkDateTimePicker/_subs/PickersContainer/_subs/TimePicker.vue
@@ -367,7 +367,7 @@
 
         await this.$nextTick()
         containers.forEach((container) => {
-          const elem = this.$refs[container][0]
+          const elem = this.$refs[container][0] || this.$refs[container]
           if (!elem) return false
 
           elem.scrollTop = 0


### PR DESCRIPTION
In vue 3, the this.$refs[container] is the element itself, hence it will skip the scroll handling part.
This added if the this.$refs[container][0] is undefined, it will take this.$refs[container] directly.

This is based from v3 alpha release